### PR TITLE
[powerpc] Collect logs for power specific components (HNV )

### DIFF
--- a/bin/supportconfig
+++ b/bin/supportconfig
@@ -1507,6 +1507,9 @@ hardware_info() {
 				log_cmd $OF "servicelog --dump"
 				log_cmd $OF "servicelog_notify --list"
 			fi
+			log_cmd $OF 'lsdevinfo'
+			log_cmd $OF 'systemctl is-enabled hcn-init.service'
+			log_files $OF 0 /var/log/hcnmgr /var/ct/IBM.DRM.stderr /var/ct/IW/log/mc/IBM.DRM/trace*
 		fi
 
 		PPC_DIR="${LOG}/ppc64"


### PR DESCRIPTION
    
This patch is to add new HNV plugin to collect
Hyper-V Network Virtualization information.
 
Signed-off-by: Mamatha Inamdar <mamatha4@linux.vnet.ibm.com>