### PR TITLE
ha.txt: Fix pacemaker.log location for SLE15

### DIFF
--- a/bin/supportconfig
+++ b/bin/supportconfig
@@ -2663,7 +2663,7 @@ ha_info() {
 			fi
 			log_cmd $OF 'cibadmin -Q'
 			conf_files $OF $CURRENT_CIB $FILES
-			FILES="/var/log/ha-log /var/log/pacemaker.log /var/log/ctdb/log.ctdb"
+			FILES="/var/log/ha-log /var/log/pacemaker/pacemaker.log /var/log/ctdb/log.ctdb"
 			test $ADD_OPTION_LOGS -gt 0 && log_files $OF 0 $FILES || log_files $OF $VAR_OPTION_LINE_COUNT $FILES
 			CORBIN="/usr/sbin/corosync-fplay"
 			if [[ -x $CORBIN ]]; then


### PR DESCRIPTION
SLE15 pacemaker logs to `/var/log/pacemaker/pacemaker.log` instead of `/var/log/pacemaker.log`