### PR TITLE
supportconfig: use readlink /proc/<pid>/cwd to get cwd list instead of lsof

### DIFF
--- a/bin/supportconfig
+++ b/bin/supportconfig
@@ -1019,16 +1019,16 @@ sssd_info() {
 			SSSD_PID=""
 		fi
 		if [ -n "$SSSD_PID" ]; then
-			SSSD_PIDS=$(ps axwwo pid,ppid,cmd | grep ${SSSD_PID} | grep -v grep | awk '{print $1}' | sort -n)
-			log_cmd $OF "ps axwwo user,pid,ppid,%cpu,%mem,vsz,rss,stat,time,cmd | egrep \"${SSSD_PID}|PPID\" | grep -v grep"
-			for THISPID in $SSSD_PIDS
-			do
-				log_cmd $OF "lsof -p $THISPID"
-			done
+			GREPTERM="$SSSD_PID"
 		else
-			log_cmd $OF "ps axwwo user,pid,ppid,%cpu,%mem,vsz,rss,stat,time,cmd | egrep \"sssd|PPID\" | grep -v grep"
-			log_cmd $OF "lsof | grep sssd"
+			GREPTERM="sssd"
 		fi
+		SSSD_PIDS=$(ps axwwo pid,ppid,cmd | grep ${GREPTERM} | grep -v grep | awk '{print $1}' | sort -n)
+		log_cmd $OF "ps axwwo user,pid,ppid,%cpu,%mem,vsz,rss,stat,time,cmd | egrep \"${GREPTERM}|PPID\" | grep -v grep"
+		for THISPID in $SSSD_PIDS
+		do
+			log_cmd $OF "lsof -p $THISPID"
+		done
 		log_cmd $OF 'grep pam_sss /etc/pam.d/*'
 		FILES="/var/log/sssd/*"
 		[ $ADD_OPTION_LOGS -gt 0 ] && log_files $OF 0 $FILES || log_files $OF $VAR_OPTION_LINE_COUNT $FILES

--- a/bin/supportconfig
+++ b/bin/supportconfig
@@ -2333,8 +2333,8 @@ crash_info() {
 		COREFILE=$(echo $CORE | sed -e 's/\%./\*/g')
 	fi
 
-	# Search CWD per lsof
-	SEARCH="$(lsof -b +M -n -l 2>/dev/null | grep '[[:space:]]cwd[[:space:]]' | awk '{print $9}' | sort | uniq)"
+	# Search CWD per /proc/<pid>/cwd
+	SEARCH="$(readlink /proc/*/cwd | sort | uniq)"
 	for i in $SEARCH
 	do
 		ls -l --time-style=long-iso ${i}/${COREFILE} ${i}/${COREFILE}\.* ${i}/core ${i}/core\.* >> $SEARCH_LIST 2>/dev/null

--- a/bin/supportconfig
+++ b/bin/supportconfig
@@ -1009,23 +1009,22 @@ sssd_info() {
 		log_cmd $OF 'ls -lR --time-style=long-iso /var/lib/sss/'
 		if (( SLES_VER < 120 )); then
 			[ -s /etc/init.d/sssd ] && SSSD_PIDF=$(grep '^PID_FILE' /etc/init.d/sssd | sed -e 's/ *//g' | cut -d= -f2)
-			test -z "$SSSD_PIDF" && SLAPD_PIDF="/var/run/sssd.pid"
-			if [ -f $SSSD_PIDF ]; then
-				SSSD_PID=$(cat $SSSD_PIDF)
-			else
-				SSSD_PID=""
-			fi
-			if [ -n "$SSSD_PID" ]; then
-				SSSD_PIDS=$(ps axwwo pid,ppid,cmd | grep ${SSSD_PID} | grep -v grep | awk '{print $1}' | sort -n)
-				log_cmd $OF "ps axwwo user,pid,ppid,%cpu,%mem,vsz,rss,stat,time,cmd | egrep \"${SSSD_PID}|PPID\" | grep -v grep"
-				for THISPID in $SSSD_PIDS
-				do
-					log_cmd $OF "lsof -p $THISPID"
-				done
-			else
-				log_cmd $OF "ps axwwo user,pid,ppid,%cpu,%mem,vsz,rss,stat,time,cmd | egrep \"sssd|PPID\" | grep -v grep"
-				log_cmd $OF "lsof | grep sssd"
-			fi
+		else
+			SSSD_PIDF=$(systemctl --property PIDFile show sssd.service | cut -d= -f2)
+		fi
+		test -z "$SSSD_PIDF" && SSSD_PIDF="/var/run/sssd.pid"
+		if [ -f $SSSD_PIDF ]; then
+			SSSD_PID=$(cat $SSSD_PIDF)
+		else
+			SSSD_PID=""
+		fi
+		if [ -n "$SSSD_PID" ]; then
+			SSSD_PIDS=$(ps axwwo pid,ppid,cmd | grep ${SSSD_PID} | grep -v grep | awk '{print $1}' | sort -n)
+			log_cmd $OF "ps axwwo user,pid,ppid,%cpu,%mem,vsz,rss,stat,time,cmd | egrep \"${SSSD_PID}|PPID\" | grep -v grep"
+			for THISPID in $SSSD_PIDS
+			do
+				log_cmd $OF "lsof -p $THISPID"
+			done
 		else
 			log_cmd $OF "ps axwwo user,pid,ppid,%cpu,%mem,vsz,rss,stat,time,cmd | egrep \"sssd|PPID\" | grep -v grep"
 			log_cmd $OF "lsof | grep sssd"


### PR DESCRIPTION
Running lsof unrestricted can be time consuming on some systems, such as
systems with dax enabled filesystems on NVMe.

For this use case, the same info can be acquired with less overhead using
'readlink /proc/*/cwd'