### PR TITLE
supportconfig: sssd_info consistency

### DIFF
--- a/bin/supportconfig
+++ b/bin/supportconfig
@@ -1019,16 +1019,16 @@ sssd_info() {
 			SSSD_PID=""
 		fi
 		if [ -n "$SSSD_PID" ]; then
-			SSSD_PIDS=$(ps axwwo pid,ppid,cmd | grep ${SSSD_PID} | grep -v grep | awk '{print $1}' | sort -n)
-			log_cmd $OF "ps axwwo user,pid,ppid,%cpu,%mem,vsz,rss,stat,time,cmd | egrep \"${SSSD_PID}|PPID\" | grep -v grep"
-			for THISPID in $SSSD_PIDS
-			do
-				log_cmd $OF "lsof -p $THISPID"
-			done
+			GREPTERM="$SSSD_PID"
 		else
-			log_cmd $OF "ps axwwo user,pid,ppid,%cpu,%mem,vsz,rss,stat,time,cmd | egrep \"sssd|PPID\" | grep -v grep"
-			log_cmd $OF "lsof | grep sssd"
+			GREPTERM="sssd"
 		fi
+		SSSD_PIDS=$(ps axwwo pid,ppid,cmd | grep ${GREPTERM} | grep -v grep | awk '{print $1}' | sort -n)
+		log_cmd $OF "ps axwwo user,pid,ppid,%cpu,%mem,vsz,rss,stat,time,cmd | egrep \"${GREPTERM}|PPID\" | grep -v grep"
+		for THISPID in $SSSD_PIDS
+		do
+			log_cmd $OF "lsof -p $THISPID"
+		done
 		log_cmd $OF 'grep pam_sss /etc/pam.d/*'
 		FILES="/var/log/sssd/*"
 		[ $ADD_OPTION_LOGS -gt 0 ] && log_files $OF 0 $FILES || log_files $OF $VAR_OPTION_LINE_COUNT $FILES

--- a/bin/supportconfig
+++ b/bin/supportconfig
@@ -1009,23 +1009,22 @@ sssd_info() {
 		log_cmd $OF 'ls -lR --time-style=long-iso /var/lib/sss/'
 		if (( SLES_VER < 120 )); then
 			[ -s /etc/init.d/sssd ] && SSSD_PIDF=$(grep '^PID_FILE' /etc/init.d/sssd | sed -e 's/ *//g' | cut -d= -f2)
-			test -z "$SSSD_PIDF" && SLAPD_PIDF="/var/run/sssd.pid"
-			if [ -f $SSSD_PIDF ]; then
-				SSSD_PID=$(cat $SSSD_PIDF)
-			else
-				SSSD_PID=""
-			fi
-			if [ -n "$SSSD_PID" ]; then
-				SSSD_PIDS=$(ps axwwo pid,ppid,cmd | grep ${SSSD_PID} | grep -v grep | awk '{print $1}' | sort -n)
-				log_cmd $OF "ps axwwo user,pid,ppid,%cpu,%mem,vsz,rss,stat,time,cmd | egrep \"${SSSD_PID}|PPID\" | grep -v grep"
-				for THISPID in $SSSD_PIDS
-				do
-					log_cmd $OF "lsof -p $THISPID"
-				done
-			else
-				log_cmd $OF "ps axwwo user,pid,ppid,%cpu,%mem,vsz,rss,stat,time,cmd | egrep \"sssd|PPID\" | grep -v grep"
-				log_cmd $OF "lsof | grep sssd"
-			fi
+		else
+			SSSD_PIDF=$(systemctl --property PIDFile show sssd.service | cut -d= -f2)
+		fi
+		test -z "$SSSD_PIDF" && SSSD_PIDF="/var/run/sssd.pid"
+		if [ -f $SSSD_PIDF ]; then
+			SSSD_PID=$(cat $SSSD_PIDF)
+		else
+			SSSD_PID=""
+		fi
+		if [ -n "$SSSD_PID" ]; then
+			SSSD_PIDS=$(ps axwwo pid,ppid,cmd | grep ${SSSD_PID} | grep -v grep | awk '{print $1}' | sort -n)
+			log_cmd $OF "ps axwwo user,pid,ppid,%cpu,%mem,vsz,rss,stat,time,cmd | egrep \"${SSSD_PID}|PPID\" | grep -v grep"
+			for THISPID in $SSSD_PIDS
+			do
+				log_cmd $OF "lsof -p $THISPID"
+			done
 		else
 			log_cmd $OF "ps axwwo user,pid,ppid,%cpu,%mem,vsz,rss,stat,time,cmd | egrep \"sssd|PPID\" | grep -v grep"
 			log_cmd $OF "lsof | grep sssd"


### PR DESCRIPTION
Use 'systemctl --properties PIDFile show sssd.service' to get the pid file location on SLES12 and later.

If we cannot get the pidfile, set the proper variable to the default pidfile.

Produce consistent output whether we get the pids from the pidfile, or from the process list and reduce
duplicated code.

Do not run 'lsof | grep sssd' as this can be an expensive operation to run on some systems
(filesystems on NVMe devices mounted with dax enabled). Without this change, this command
could be run if sssd was simply installed, but not currently running.