### PR TITLE
Don't pull in net-tools

### DIFF
--- a/spec/supportutils.changes
+++ b/spec/supportutils.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Mar  3 14:12:42 UTC 2021 - Thorsten Kukuk <kukuk@suse.com>
+
+- Remove net-tools from requires, it does not contain any tool
+  anymore used by supportutils
+
+-------------------------------------------------------------------
 Tue Mar  2 14:45:38 UTC 2021 - Mike Latimer mlatimer@suse.com
 
 - Collect logs for power specific components (using iprconfig) #94

--- a/spec/supportutils.spec
+++ b/spec/supportutils.spec
@@ -29,7 +29,6 @@ Source:         %{name}-%{version}.tar.gz
 Requires:       iproute2
 Requires:       kmod-compat
 Requires:       ncurses-utils
-Requires:       net-tools
 Requires:       sysfsutils
 Requires:       tar
 Requires:       util-linux-systemd


### PR DESCRIPTION
supportutils still requires net-tools, but does not use and need it. Remove that requires, else we have to install and support net-tools on all systems even if we don't need and want that.