### PR TITLE
Minor: Fix a typo (executible -> executable)

### DIFF
--- a/bin/scplugin.rc
+++ b/bin/scplugin.rc
@@ -89,7 +89,7 @@ plugin_command() {
 		EXIT_STATUS=$?
 	else
 		echo "# $CMDLINE_ORIG"
-		echo "ERROR: Command not found or not executible"
+		echo "ERROR: Command not found or not executable"
 		EXIT_STATUS=1
 	fi
 	echo

--- a/bin/supportconfig.rc
+++ b/bin/supportconfig.rc
@@ -421,7 +421,7 @@ log_cmd() {
 		wait_trace_off
 	else
 		echo "# $CMDLINE_ORIG" >> $LOGFILE
-		echo "ERROR: Command not found or not executible" >> $LOGFILE
+		echo "ERROR: Command not found or not executable" >> $LOGFILE
 		EXIT_STATUS=1
 	fi
 	echo >> $LOGFILE
@@ -505,7 +505,7 @@ TEOF
 		wait_trace_off
 	else
 		echo "# $CMDLINE_ORIG" >> $LOGFILE
-		echo "ERROR: Command not found or not executible" >> $LOGFILE
+		echo "ERROR: Command not found or not executable" >> $LOGFILE
 		EXIT_STATUS=1
 	fi
 	echo >> $LOGFILE
@@ -758,7 +758,7 @@ exec_plugins() {
 					fi
 				fi
 			else
-				log_write $PLUGIN_LOG_FILE "ERROR: Missing or non-executible plugin"
+				log_write $PLUGIN_LOG_FILE "ERROR: Missing or non-executable plugin"
 				((PLUGIN_ERROR++))
 			fi
 			log_write $PLUGIN_LOG_FILE


### PR DESCRIPTION
When browsing the supportconfig data, I always get hit by this typo. It's not that important, just a bit annoying.