### PR TITLE
rpcinfo -p output added 

### DIFF
--- a/bin/supportconfig
+++ b/bin/supportconfig
@@ -2088,6 +2088,7 @@ nfs_info() {
 				check_service $OF nfsserver
 				NFS_STATUS=$?
 			fi
+			timed_log_cmd $OF 'rpcinfo -p'
 			log_cmd $OF 'exportfs -v'
 			log_cmd $OF 'nfsstat'
 			if timed_log_cmd $OF 'showmount'


### PR DESCRIPTION
rpcinfo -p output added for the local host. Used timed_log_cmd as it can sometimes take several minutes. Usually this is takes a second or less to return on my tests