### PR TITLE
Add support for running getappcore inside a container.

### DIFF
--- a/bin/getappcore
+++ b/bin/getappcore
@@ -62,6 +62,8 @@ SUSE_RELEASE="/etc/SuSE-release"
 OS_RELEASE="/etc/os-release"
 ARCHIVE_PREFIX='scc_'
 JOURNAL_PID=''
+CONTAINER_IMAGE=''
+PODMAN_BIN='/usr/bin/podman'
 TAR_BIN_OPTIONS=''
 TAR_BIN_EXT=''
 UPLOAD=0
@@ -82,7 +84,7 @@ UPLOAD_TARGET="${DEFAULT_HTTPS}"
 AWK_BIN=/usr/bin/awk
 BASENAME_BIN=/usr/bin/basename
 CAT_BIN=/bin/cat
-CHKBIN_BIN=/usr/sbin/chkbin
+CHKBIN_BIN=/sbin/chkbin
 CHMOD_BIN=/bin/chmod
 COREDUMP_BIN=/usr/bin/coredumpctl
 CURL_BIN=/usr/bin/curl
@@ -158,6 +160,7 @@ show_help() {
 	echo "  -r [SR Number]  SUSE Service Request number associated with this issue"
 	echo "  -u              Automatically upload archive to the SUSE FTP server using HTTPS"
 	echo "  -f              Automatically upload archive to the SUSE FTP server using FTPES"
+	echo "  -c [IMAGE]      Runs inside the container image [IMAGE]"
 	echo "  -v              Enable verbose messages"
 	echo
 	echo "For example:"
@@ -481,12 +484,49 @@ upload_archive() {
 	echo
 }
 
+# --------------------------------------------------------- #
+# prepare_run_script_for_container ()                       #
+# Creates a temporary script for running getappcore inside  #
+# a container.                                              #
+# It installs the getappcore basic dependencies and runs    #
+# getappcore with the given core file                       #
+# --------------------------------------------------------- #
+prepare_run_script_for_container() {
+cat <<- EOF > ${GETAPPCORE_TMP_DIR}/runincontainer
+#!/bin/bash
+COREFILE=$1
+zypper in -y supportutils gdb curl file systemd-coredump
+/sbin/getappcore $COREFILE
+EOF
+chmod +x ${GETAPPCORE_TMP_DIR}/runincontainer
+}
+
+# --------------------------------------------------------- #
+# run_in_container ()                                       #
+# Creates a temporary script for running getappcore inside  #
+# a container.                                              #
+# It installs the getappcore basic dependencies and runs    #
+# getappcore with the given core file                       #
+# --------------------------------------------------------- #
+run_in_container() {
+	if ! [ -e $PODMAN_BIN ]; then
+		echo "podman is required for running getappcore inside a container."
+		echo "Please install podman and try again."
+		exit 1
+	fi
+	CONTAINER_IMAGE=$1
+	[[ $JOURNAL_PID ]] && get_journal_coredump $JOURNAL_PID
+	if [ ! -z $COREFILE -a -e $COREFILE ]; then
+		prepare_run_script_for_container
+		$PODMAN_BIN run -it --entrypoint=/tmp/sbin/runincontainer -v ${ARCHIVE_PATH}:${ARCHIVE_PATH} -v ${GETAPPCORE_TMP_DIR}:/tmp/sbin $CONTAINER_IMAGE $COREFILE
+	fi
+}
 
 # --------------------------------------------------------- #
 # main ()                                                   #
 # Main script function                                      #
 # --------------------------------------------------------- #
-while getopts b:hr:ufvj: opt
+while getopts b:hr:ufvj:c: opt
 do
 	case $opt in
 	\?)
@@ -515,6 +555,9 @@ do
 		;;
 	j)
 		JOURNAL_PID=$OPTARG
+		;;
+	c)
+		CONTAINER_IMAGE=$OPTARG
 		;;
 	h)
 		get_server_release
@@ -548,6 +591,12 @@ else
 fi
 
 [[ -d ${ARCHIVE_PATH} ]] || mkdir -p ${ARCHIVE_PATH}
+
+if [[ ! -z $CONTAINER_IMAGE ]]; then
+	echo "Running getappcore in container image: ${CONTAINER_IMAGE}"
+	run_in_container $CONTAINER_IMAGE
+	exit 0
+fi
 
 [[ $JOURNAL_PID ]] && get_journal_coredump $JOURNAL_PID
 


### PR DESCRIPTION
Adding container support for getappcore.

This was raised after a bug opened by support, having to deal with core files originated by binaries containerised.

The idea is to add a new parameter **-c [IMAGE]** to indicate getappcore that it should run inside the given container image.
It basically generates a temporary script that serves as the entry point in which installs the required dependencies inside the container and runs getappcore with the given core file.

This is an example of the execution:

Find the coredump and PID from the host.
```bash
$ coredumpctl
TIME                            PID   UID   GID SIG COREFILE  EXE
Mon 2022-04-25 09:32:36 CEST   3936   167   167  11 present   /usr/bin/ceph-osd
```

We know this binary was executed in the container image: **registry.suse.de/devel/storage/7.0/pacific/containers/ses/7.1/ceph/ceph@sha256:383de7050799ddc84d7b780c5bb507e9633694b002cf41b3e6852a678ecb1d93**

Calling getappcore passing the container image:
```bash
$ getappcore -j 3936 -c registry.suse.de/devel/storage/7.0/pacific/containers/ses/7.1/ceph/ceph@sha256:383de7050799ddc84d7b780c5bb507e9633694b002cf41b3e6852a678ecb1d93
####################################################################
Get Application Core Tool, v1.53.01
Date:     04/27/22, 14:29:59
Server:   node1
OS:       SUSE Linux Enterprise Server 15 SP3
Kernel:   5.3.18-150300.59.60-default (x86_64)
Corefile: PID 3936
####################################################################

Local configuration file... None
Running getappcore in container image: registry.suse.de/devel/storage/7.0/pacific/containers/ses/7.1/ceph/ceph@sha256:383de7050799ddc84d7b780c5bb507e9633694b002cf41b3e6852a678ecb1d93
Retrieving core file with PID 3936... Done
WARN[0000] Path "/etc/SUSEConnect" from "/etc/containers/mounts.conf" doesn't exist, skipping
WARN[0000] Path "/etc/zypp/credentials.d/SCCcredentials" from "/etc/containers/mounts.conf" doesn't exist, skipping
Refreshing service 'container-suseconnect-zypp'.
Problem retrieving the repository index file for service 'container-suseconnect-zypp':
[container-suseconnect-zypp|file:/usr/lib/zypp/plugins/services/container-suseconnect-zypp]
Warning: Skipping service 'container-suseconnect-zypp' because of the above error.
Building repository 'SLE_BCI' cache ....................................................................................................[done]
Loading repository data...
Reading installed packages...
Resolving package dependencies...

The following 11 NEW packages are going to be installed:
  curl file gdb iproute2 libmnl0 libmpfr6 libxtables12 supportutils sysfsutils systemd-coredump tar

The following 11 packages are not supported by their vendor:
  curl file gdb iproute2 libmnl0 libmpfr6 libxtables12 supportutils sysfsutils systemd-coredump tar

11 new packages to install.
Overall download size: 6.5 MiB. Already cached: 0 B. After the operation, additional 19.0 MiB will be used.
Continue? [y/n/v/...? shows all options] (y): y
Retrieving package curl-7.66.0-4.27.1.x86_64                                                            (1/11), 330.4 KiB (471.2 KiB unpacked)
Retrieving: curl-7.66.0-4.27.1.x86_64.rpm ..............................................................................................[done]
Retrieving package file-5.32-7.14.1.x86_64                                                              (2/11),  50.0 KiB ( 81.3 KiB unpacked)
Retrieving: file-5.32-7.14.1.x86_64.rpm ................................................................................................[done]
Retrieving package libmnl0-1.0.4-1.25.x86_64                                                            (3/11),  16.4 KiB ( 22.4 KiB unpacked)
Retrieving: libmnl0-1.0.4-1.25.x86_64.rpm ..............................................................................................[done]
Retrieving package libmpfr6-4.0.2-3.3.1.x86_64                                                          (4/11), 216.1 KiB (500.6 KiB unpacked)
Retrieving: libmpfr6-4.0.2-3.3.1.x86_64.rpm ............................................................................................[done]
Retrieving package libxtables12-1.8.7-1.1.x86_64                                                        (5/11),  34.3 KiB ( 58.9 KiB unpacked)
Retrieving: libxtables12-1.8.7-1.1.x86_64.rpm ..........................................................................................[done]
Retrieving package sysfsutils-2.1.0-3.3.1.x86_64                                                        (6/11),  36.7 KiB ( 88.7 KiB unpacked)
Retrieving: sysfsutils-2.1.0-3.3.1.x86_64.rpm ..........................................................................................[done]
Retrieving package systemd-coredump-246.16-150300.7.42.1.x86_64                                         (7/11), 240.7 KiB ( 99.7 KiB unpacked)
Retrieving: systemd-coredump-246.16-150300.7.42.1.x86_64.rpm ...........................................................................[done]
Retrieving package tar-1.30-3.9.1.x86_64                                                                (8/11), 209.5 KiB (470.6 KiB unpacked)
Retrieving: tar-1.30-3.9.1.x86_64.rpm ..................................................................................................[done]
Retrieving package gdb-11.1-8.30.1.x86_64                                                               (9/11),   4.4 MiB ( 14.6 MiB unpacked)
Retrieving: gdb-11.1-8.30.1.x86_64.rpm .................................................................................................[done]
Retrieving package iproute2-5.3-5.5.1.x86_64                                                           (10/11), 894.1 KiB (  2.5 MiB unpacked)
Retrieving: iproute2-5.3-5.5.1.x86_64.rpm ..............................................................................................[done]
Retrieving package supportutils-3.1.20-150300.7.35.10.1.noarch                                         (11/11),  95.5 KiB (287.9 KiB unpacked)
Retrieving: supportutils-3.1.20-150300.7.35.10.1.noarch.rpm ............................................................................[done]

Checking for file conflicts: ...........................................................................................................[done]
( 1/11) Installing: curl-7.66.0-4.27.1.x86_64 ..........................................................................................[done]
( 2/11) Installing: file-5.32-7.14.1.x86_64 ............................................................................................[done]
( 3/11) Installing: libmnl0-1.0.4-1.25.x86_64 ..........................................................................................[done]
( 4/11) Installing: libmpfr6-4.0.2-3.3.1.x86_64 ........................................................................................[done]
( 5/11) Installing: libxtables12-1.8.7-1.1.x86_64 ......................................................................................[done]
( 6/11) Installing: sysfsutils-2.1.0-3.3.1.x86_64 ......................................................................................[done]
( 7/11) Installing: systemd-coredump-246.16-150300.7.42.1.x86_64 .......................................................................[done]
( 8/11) Installing: tar-1.30-3.9.1.x86_64 ..............................................................................................[done]
( 9/11) Installing: gdb-11.1-8.30.1.x86_64 .............................................................................................[done]
(10/11) Installing: iproute2-5.3-5.5.1.x86_64 ..........................................................................................[done]
(11/11) Installing: supportutils-3.1.20-150300.7.35.10.1.noarch ........................................................................[done]
####################################################################
Get Application Core Tool, v1.53.01
Date:     04/27/22, 12:30:04
Server:   99f465fe64e2
OS:       SUSE Linux Enterprise Server 15 SP3
Kernel:   5.3.18-150300.59.60-default (x86_64)
Corefile: /var/log/core.3936
####################################################################

Local configuration file... None
Validating core file... Done
Validating binary file... Done
Checking Source Binary with chkbin... Done
Building list of required libraries... Done
Building list of required RPMs... Done
Building list of debuginfo RPMs...  Done
Setting gdb environment variables... Done
Creating gdb startup files... Done
Creating core archive... Done

Affected Binary: /usr/bin/ceph-osd
Coredump File:   /var/log/core.3936
Archive Name:    /var/log/scc_99f465fe64e2_ceph-osd_220427_123004_appcore.txz
Removing required files and directories ... Done

Finished!
```
We can access now the final archive in the host.

**Note** 
I've also changed the expected path in which getappcore expects to find chkbin as it was being installed to /sbin, but getappcore was expecting it in /usr/sbin/

Fixes: https://bugzilla.suse.com/show_bug.cgi?id=1181668

Signed-off-by: 0xavi0 <xavi.garcia@suse.com>