### PR TITLE
Added a listing to /dev/mapper/.  

### DIFF
--- a/bin/supportconfig
+++ b/bin/supportconfig
@@ -1897,6 +1897,7 @@ disk_info() {
 	done
 
 	log_cmd $OF 'ls -lR --time-style=long-iso /dev/disk/'
+        log_cmd $OF 'ls -l --time-style=long-iso /dev/mapper/'
 	log_cmd $OF 'ls -l --time-style=long-iso /sys/block/'
 	log_cmd $OF 'lslocks'
 


### PR DESCRIPTION
I have needed a listing of /dev/mapper/ several times lately but it was not yet included in the supportconfig. I have also had 2 requests for this feature in the last month. This will fit nicely with the listings in /dev/disk/by-*/ and the multipath outputs