### PR TITLE
Add extra cleanup to remove possible passwords (bsc#1201059)

### DIFF
--- a/bin/supportconfig
+++ b/bin/supportconfig
@@ -3330,7 +3330,7 @@ etc_info() {
 	conf_files $OF $(find -L /etc/ -type f | egrep "conf$|cfg$" | egrep -v "rhn/rhn.conf$")
 	[ -d /etc/logrotate.d ] && conf_files $OF /etc/logrotate.d/*
 	conf_files $OF /etc/rc.dialout /etc/ppp/options /etc/ppp/ioptions /etc/ppp/peers/pppoe /etc/motd
-        sed -i -e 's/\(.*pass:\).*/\1 *REMOVED BY SUPPORTCONFIG*/g;s/\(.*password:\).*/\1 *REMOVED BY SUPPORTCONFIG*/g;s/\(.*pass[[:space:]]*=\).*/\1 *REMOVED BY SUPPORTCONFIG*/g;s/\(.*password[[:space:]]*=\).*/\1 *REMOVED BY SUPPORTCONFIG*/g' $LOG/$OF
+        sed -i -e 's/\(.*pass:\).*/\1 *REMOVED BY SUPPORTCONFIG*/g;s/\(.*password:\).*/\1 *REMOVED BY SUPPORTCONFIG*/g;s/\(.*pass[[:space:]]*=\).*/\1 *REMOVED BY SUPPORTCONFIG*/g;s/\(.*password[[:space:]]*=\).*/\1 *REMOVED BY SUPPORTCONFIG*/g;s/\(.*GPGPASS=\).*/\1*REMOVED BY SUPPORTCONFIG*/g' $LOG/$OF
 	echolog Done
 }
 
@@ -3351,7 +3351,7 @@ sysconfig_info() {
 		done
 	done
 	sed -i -e 's/.*_PASSWORD[[:space:]]*=.*/*REMOVED BY SUPPORTCONFIG*/g;s/.*_password[[:space:]]*=.*/*REMOVED BY SUPPORTCONFIG*/g' $LOG/$OF
-        sed -i -e 's/\(.*pass:\).*/\1 *REMOVED BY SUPPORTCONFIG*/g;s/\(.*password:\).*/\1 *REMOVED BY SUPPORTCONFIG*/g;s/\(.*pass[[:space:]]*=\).*/\1 *REMOVED BY SUPPORTCONFIG*/g;s/\(.*password[[:space:]]*=\).*/\1 *REMOVED BY SUPPORTCONFIG*/g' $LOG/$OF
+        sed -i -e 's/\(.*pass:\).*/\1 *REMOVED BY SUPPORTCONFIG*/g;s/\(.*password:\).*/\1 *REMOVED BY SUPPORTCONFIG*/g;s/\(.*pass[[:space:]]*=\).*/\1 *REMOVED BY SUPPORTCONFIG*/g;s/\(.*password[[:space:]]*=\).*/\1 *REMOVED BY SUPPORTCONFIG*/g;s/\(.*GPGPASS=\).*/\1*REMOVED BY SUPPORTCONFIG*/g' $LOG/$OF
 	echolog Done
 }
 

--- a/bin/supportconfig
+++ b/bin/supportconfig
@@ -3330,6 +3330,7 @@ etc_info() {
 	conf_files $OF $(find -L /etc/ -type f | egrep "conf$|cfg$" | egrep -v "rhn/rhn.conf$")
 	[ -d /etc/logrotate.d ] && conf_files $OF /etc/logrotate.d/*
 	conf_files $OF /etc/rc.dialout /etc/ppp/options /etc/ppp/ioptions /etc/ppp/peers/pppoe /etc/motd
+        sed -i -e 's/\(.*pass:\).*/\1 *REMOVED BY SUPPORTCONFIG*/g;s/\(.*password:\).*/\1 *REMOVED BY SUPPORTCONFIG*/g;s/\(.*pass[[:space:]]*=\).*/\1 *REMOVED BY SUPPORTCONFIG*/g;s/\(.*password[[:space:]]*=\).*/\1 *REMOVED BY SUPPORTCONFIG*/g' $LOG/$OF
 	echolog Done
 }
 
@@ -3349,7 +3350,8 @@ sysconfig_info() {
 			conf_files $OF $FILE
 		done
 	done
-	sed -i -e 's/.*_PASSWORD[[:space:]]*=.*/*REMOVED BY SUPPORTCONFIG*/g' $LOG/$OF
+	sed -i -e 's/.*_PASSWORD[[:space:]]*=.*/*REMOVED BY SUPPORTCONFIG*/g;s/.*_password[[:space:]]*=.*/*REMOVED BY SUPPORTCONFIG*/g' $LOG/$OF
+        sed -i -e 's/\(.*pass:\).*/\1 *REMOVED BY SUPPORTCONFIG*/g;s/\(.*password:\).*/\1 *REMOVED BY SUPPORTCONFIG*/g;s/\(.*pass[[:space:]]*=\).*/\1 *REMOVED BY SUPPORTCONFIG*/g;s/\(.*password[[:space:]]*=\).*/\1 *REMOVED BY SUPPORTCONFIG*/g' $LOG/$OF
 	echolog Done
 }
 


### PR DESCRIPTION
This PR adds extra password cleanup for the files included in the tarball, particularly around `/etc/` and sysconfig files.

With these changes we are replacing any possible password with the following patterns:

- `.*pass:`
- `.*pass[[:space:]]*=`
- `.*password:`
- `.*password[[:space:]]*=`
- `.*_password[[:space:]]*=.*`
- `^GPGPASS=`

Tracks: https://github.com/SUSE/spacewalk/issues/18286