### PR TITLE
print full kernel name in output of last

### DIFF
--- a/bin/supportconfig
+++ b/bin/supportconfig
@@ -745,7 +745,7 @@ boot_info() {
 
 	test -e /usr/sbin/mcelog && log_cmd $OF "/usr/sbin/mcelog --ignorenodev --filter --dmi"
 	test -s /var/log/mcelog && { log_cmd $OF "ls -l --time-style=long-iso /var/log/mcelog"; conf_files $OF /var/log/mcelog; }
-	log_cmd $OF 'last -xF | egrep "reboot|shutdown|runlevel|system"'
+	log_cmd $OF 'last -wxF | egrep "reboot|shutdown|runlevel|system"'
 
 	(( SLES_VER >= 120 )) && FILES='/var/log/boot.log' || FILES='/etc/inittab'
 	conf_files $OF /proc/cmdline /etc/sysconfig/kernel $FILES /etc/init.d/boot.local /etc/init.d/before.local /etc/init.d/after.local /etc/init.d/halt.local


### PR DESCRIPTION
SUSE kernel naming has changed and this caused last to truncate the kernel name:
reboot   system boot  5.14.21-150400.2 Mon Aug 15 15:17:49 2022   still running
The added option fixes that:
reboot   system boot  5.14.21-150400.24.18-default Mon Aug 15 15:17:49 2022   still running

Signed-off-by: Jiri Wiesner <jwiesner@suse.de>