### PR TITLE
Get Lifecycle Information

### DIFF
--- a/bin/supportconfig
+++ b/bin/supportconfig
@@ -862,6 +862,10 @@ update_info() {
 			conf_files $OF /etc/SUSEConnect $FILES
 		fi
 	fi
+	
+	if rpm -q zypper-lifecycle-plugin &> /dev/null; then
+                log_cmd $OF 'zypper lifecycle'
+        fi
 
 	if rpm -q libzypp &> /dev/null; then
 		QPBIN=$(rpm -ql libzypp | grep query-pool)


### PR DESCRIPTION
We have zypper lifecycle ; it report outdated rpms and the status of the OS. Let us take a copy of it.  I have added: 
if rpm -q zypper-lifecycle-plugin &> /dev/null; then
                log_cmd $OF 'zypper lifecycle'
        fi