### PR TITLE
Add dependency to `numactl` on ppc64le and `s390x`

### DIFF
--- a/spec/supportutils.changes
+++ b/spec/supportutils.changes
@@ -1,3 +1,9 @@
+Thu Feb 02 16:53:23 UTC 2023 - hp.jansen@suse.com
+-------------------------------------------------------------------
+
+- Add dependency to `numactl` on ppc64le and `s390x`, this enforces
+  that `numactl --hardware` data is provided in supportconfigs
+
 -------------------------------------------------------------------
 Thu Jan 26 15:58:24 UTC 2023 - jason.record@suse.com
 

--- a/spec/supportutils.spec
+++ b/spec/supportutils.spec
@@ -33,6 +33,9 @@ Source:         %{name}-%{version}.tar.gz
 Requires:       iproute2
 Requires:       kmod-compat
 Requires:       ncurses-utils
+%ifarch ppc64le s390x
+Requires:       numactl
+%endif
 Requires:       sysfsutils
 Requires:       tar
 Requires:       util-linux-systemd


### PR DESCRIPTION
This enforces, that `numactl --hardware` data is provided in supportconfigs of those platforms.

To be honest, I think, it can go in unconditionally, but on those platforms, this allows us to better understand the LPAR environment. Specifically, this is able to point out deficits in the LPAR setup, that we cannot determine otherwise.