### PR TITLE
[powerpc]: To collect lparnumascore logs

### DIFF
--- a/bin/supportconfig
+++ b/bin/supportconfig
@@ -1649,6 +1649,9 @@ hardware_info() {
 				log_cmd $OF "serv_config -l"
 				log_cmd $OF "bootlist -m both -r"
 				log_cmd $OF "lparstat -i"
+				log_cmd $OF "lparnumascore"
+				log_cmd $OF "lparnumascore -c cpu -d 4"
+				log_cmd $OF "lparnumascore -c mem -d 3"
 			fi
 		fi
 		if rpm -q lsvpd &>/dev/null; then


### PR DESCRIPTION
This patch is to update hardware plugin to
collect lparnumascore logs.

Lparnumascore displays the NUMA affinity score
for the running LPAR.The following commands are added
lparnumascore
lparnumascore -c cpu -d 4
lparnumascore -c mem -d 3

Suggested-by: Laurent Dufour <ldufour@linux.ibm.com>