### PR TITLE
ha_info sle15 uses /var/log/pacemaker/

### DIFF
--- a/bin/supportconfig
+++ b/bin/supportconfig
@@ -3106,7 +3106,7 @@ ha_info() {
 			fi
 			log_cmd $OF 'cibadmin -Q'
 			conf_files $OF $CURRENT_CIB $FILES
-			FILES="/var/log/ha-log /var/log/pacemaker.log /var/log/ctdb/log.ctdb"
+			FILES="/var/log/ha-log /var/log/pacemaker/pacemaker.log /var/log/ctdb/log.ctdb"
 			test $ADD_OPTION_LOGS -gt 0 && log_files $OF 0 $FILES || log_files $OF $VAR_OPTION_LINE_COUNT $FILES
 			CORBIN="/usr/sbin/corosync-fplay"
 			if [[ -x $CORBIN ]]; then


### PR DESCRIPTION
Fixed in #90 but 311675a reverted the location. Fixing to again use /var/log/pacemaker/pacemaker.log for SLE15