### PR TITLE
Adapt for new versions of kdump (bsc#1216146)

### DIFF
--- a/bin/analyzevmcore
+++ b/bin/analyzevmcore
@@ -258,7 +258,7 @@ checkkernel()
 	KERNEL=""
 	if [ -z "$USERKERNEL" ]; then
 		if [ -e README.txt ]; then
-			KERNEL=$($GREP_BIN "^Kernel version :" README.txt | $AWK_BIN '{print $NF}')
+			KERNEL=$($GREP_BIN "^Kernel version *:" README.txt | $AWK_BIN '{print $NF}')
 			if ! [ -z "$KERNEL" ]; then
 				KERNEL="vmlinux-$KERNEL.gz"
 			fi
@@ -535,7 +535,12 @@ fi
 if [[ -z "$COREDIR" ]]; then
 	#Source /etc/sysconfig/kdump
 	if [[ -e "/etc/sysconfig/kdump" ]]; then
-		. /etc/sysconfig/kdump
+		if [[ -x /usr/lib/kdump/kdump-read-config.sh ]]; then
+			. /usr/lib/kdump/kdump-read-config.sh
+			KDUMP_SAVEDIR=${KDUMP_SAVEDIR#file://}
+		else
+			KDUMP_SAVEDIR=$(kdumptool dump_config | grep ^KDUMP_SAVEDIR | sed -e 's/"//g' | cut -d= -f2)
+		fi
 		if [[ "${KDUMP_SAVEDIR:0:8}" = "file:///" ]]; then
 			KDUMP_SAVEDIR=${KDUMP_SAVEDIR:7}
 		elif [[ "${KDUMP_SAVEDIR:0:1}" = "/" ]]; then

--- a/bin/supportconfig
+++ b/bin/supportconfig
@@ -2615,7 +2615,7 @@ crash_info() {
 		log_cmd $OF "uname -r"
 		log_cmd $OF "systemctl status kdump.service"
 		log_cmd $OF "kdumptool calibrate"
-		log_cmd $OF "kdumptool dump_config"
+		[[ -x /usr/lib/kdump/kdump-read-config.sh ]] || log_cmd $OF "kdumptool dump_config"
 		conf_files $OF /proc/cmdline
 		conf_files $OF /etc/sysconfig/kdump
 		conf_files $OF /proc/sys/kernel/panic
@@ -2634,8 +2634,13 @@ crash_info() {
 		conf_files $OF /var/crash/*/kexec-dmesg.log
 		conf_files $OF /var/log/kdump.log
 		if rpm -q kdump &>/dev/null; then
-			DUMPDIR=$(kdumptool dump_config | grep ^KDUMP_SAVEDIR | sed -e 's/"//g;s!file://!!g' | cut -d= -f2)
-			if [[ -d $DUMPDIR ]]; then
+			if [[ -x /usr/lib/kdump/kdump-read-config.sh ]]; then
+				. /usr/lib/kdump/kdump-read-config.sh
+				DUMPDIR=${KDUMP_SAVEDIR#file://}
+			else
+				DUMPDIR=$(kdumptool dump_config | grep ^KDUMP_SAVEDIR | sed -e 's/"//g;s!file://!!g' | cut -d= -f2)
+			fi
+			if [[ -d "$DUMPDIR" ]]; then
 				log_cmd $OF "find ${DUMPDIR}/"
 			else
 				log_entry $OF conf "KDUMP_SAVEDIR not found: ${DUMPDIR}"


### PR DESCRIPTION
kdump 1.9+ does not have kdumptool dump_config and has a different format of README.txt (missing space).

Modify supportconfig to work with the above changes.

Modify analyzevmcore to read KDUMP_SAVEDIR the same way supportconfig does. this also makes it work with the new kdump versions and also will use the default value if KDUMP_SAVEDIR is not specified in te config file.

Note that the updated kdump is now in SLE15-SP6, so please push ths change to there as well.