### PR TITLE
powerpc: collect rtas_errd.log and lp_diag.log files

### DIFF
--- a/bin/supportconfig
+++ b/bin/supportconfig
@@ -1882,6 +1882,10 @@ hardware_info() {
 				log_entry $OF command "cp /sys/kernel/debug/dynamic_debug/control $PPC_DIR"
 				cp /sys/kernel/debug/dynamic_debug/control $PPC_DIR 2>/dev/null
 			fi
+			if [[ -f /var/log/rtas_errd.log ]]; then
+				log_entry $OF command "cp /var/log/rtas_errd.log $PPC_DIR"
+				cp /var/log/rtas_errd.log $PPC_DIR 2>/dev/null
+			fi
 			if rpm -q IBMinvscout &>/dev/null; then
 				log_cmd $OF "invscout"
 				log_cmd $OF "invscout -v"
@@ -1895,6 +1899,10 @@ hardware_info() {
 			;;
 		esac
 
+		if [[ -f /var/log/lp_diag.log ]]; then
+			log_entry $OF command "cp /var/log/lp_diag.log $PPC_DIR"
+			cp /var/log/lp_diag.log $PPC_DIR 2>/dev/null
+		fi
 		if [[ -d /proc/device-tree/ ]]; then
 			SAVE_DIR="${PPC_DIR}/device-tree"
 			mkdir -p $SAVE_DIR


### PR DESCRIPTION
On power systems, rtas_errd daemon logs RTAS events to servicelog database. This daemon uses /var/log/rtas_errd.log file to store debug logs. If the file is present, collect it as part of supportconfig.

Similarly, light path diagnostics log messages are written to /var/log/lp_diag.log file. If the file is present, collect it as part of supportconfig.

Signed-off-by: Sathvika Vasireddy <sv@linux.ibm.com>
Reviewed-by: Sourabh Jain <sourabhjain@linux.ibm.com>