### PR TITLE
Inhibit the conversion of port numbers to port names for network files

### DIFF
--- a/bin/supportconfig
+++ b/bin/supportconfig
@@ -3079,7 +3079,7 @@ open_files() {
 	addHeaderFile $OF
 	if rpm_verify $OF lsof
 	then
-		log_cmd $OF "lsof -b +M -n -l +fg 2>/dev/null"
+		log_cmd $OF "lsof -b +M -n -l +fg -P 2>/dev/null"
 		echolog Done
 	else
 		echolog Skipped


### PR DESCRIPTION
When checking for open ports, lsof normally translates them to a human-friendly textual name.

This means that if I want, for example, to check if there is any process listening on port 162, I need:
- to check what is the service normally running on it (/etc/services helps me and indicates "snmptrap 162/udp")
- to grep snmptrap in the lsof output.

Using -P, the conversion is avoided and I can just grep 162 (that means I can check quickly if process is on a port, without first checking the service assigned to the port)