### PR TITLE
ipset - List entries for all sets

### DIFF
--- a/bin/supportconfig
+++ b/bin/supportconfig
@@ -1891,6 +1891,10 @@ net_info_namespace() {
 	IPVSADM_BIN=$(command -v ipvsadm)
 	if [[ -x $IPVSADM_BIN ]]; then
 		log_cmd $OF "${NS}${IPVSADM_BIN} -Ln"
+
+	IPSET_BIN=$(command -v ipset)
+	if [[ -x $IPSET_BIN ]]; then
+		log_cmd $OF "${NS}${IPSET_BIN} list"
 	fi
 
 	if rpm_verify $OF nftables


### PR DESCRIPTION
When IP sets are used, the command will get all of them

This is useful when iptables is used, containing references to sets; without printing the sets, the iptables rules would be only partially understandable