### PR TITLE
[hardware_info] collect nvidia-persistenced service status

### DIFF
--- a/bin/supportconfig
+++ b/bin/supportconfig
@@ -1748,6 +1748,7 @@ hardware_info() {
 			log_cmd $OF "ls -l /var/log/dump"
 		fi
 	fi
+	log_cmd $OF "systemctl status nvidia-persistenced.service"
 	echolog Done
 }
 


### PR DESCRIPTION
Having nvidia-persistenced service status helps debugging issues with NVIDIA kernel driver behaviour with persistence mode on.


Tested-by: Borislav Stoymirski <borislav.stoymirski@bg.ibm.com>
Suggested-by: Borislav Stoymirski <borislav.stoymirski@bg.ibm.com>