### PR TITLE
Avoid getting duplicate kernel verifications in boot.text

### DIFF
--- a/bin/supportconfig
+++ b/bin/supportconfig
@@ -612,7 +612,8 @@ boot_info() {
 	OF=boot.txt
 	addHeaderFile $OF
 	log_cmd $OF "uname -a"
-	KERNELS=$(cat $LOG/$RPMFILE | grep '^kernel-' | grep -v 'kernel-source' | awk '{print $1}')
+	# Feb 6, 2024 - Ahmad Alzayed - Added grep -E '[0-9]' to avoid getting duplicated output
+	KERNELS=$(cat $LOG/$RPMFILE | grep '^kernel-' | grep -v 'kernel-source' | awk '{print $1}' | grep -E '[0-9]')
 	for KERNEL in $KERNELS
 	do
 		rpm_verify $OF $KERNEL


### PR DESCRIPTION
Feb 6, 2024 - Ahmad Alzayed - Added grep -E '[0-9]' to avoid getting duplicated output 

Without it: 
#==[ Verification ]=================================# # rpm -V kernel-default-5.3.18-150300.59.106.1.x86_64 # Verification Status: Passed

#==[ Verification ]=================================# # rpm -V kernel-firmware-20210208-150300.4.10.1.noarch # Verification Status: Passed

#==[ Verification ]=================================# # rpm -V kernel-default-5.3.18-150300.59.106.1.x86_64 # Verification Status: Passed

#==[ Verification ]=================================# # rpm -V kernel-firmware-20210208-150300.4.10.1.noarch # Verification Status: Passed

with it: 
#==[ Verification ]=================================# # rpm -V kernel-default-5.3.18-150300.59.106.1.x86_64 # Verification Status: Passed

#==[ Verification ]=================================# # rpm -V kernel-firmware-20210208-150300.4.10.1.noarch # Verification Status: Passed