### PR TITLE
docker_info: Add timestamps to container logs

### DIFF
--- a/bin/supportconfig
+++ b/bin/supportconfig
@@ -1107,7 +1107,7 @@ docker_info() {
 			CONTAINEROF=docker/"$container".txt
 			log_cmd $CONTAINEROF "docker top $container"
 			log_cmd $CONTAINEROF "docker inspect $container"
-			log_cmd $CONTAINEROF "docker logs $container"
+			log_cmd $CONTAINEROF "docker logs --timestamps $container"
 		done
 		log_cmd $OF 'ls -al --time-style=long-iso /var/lib/docker/containers'
 		log_cmd $OF 'journalctl -u docker'


### PR DESCRIPTION
Force add timestamps to container logs. By default, `docker logs` does not add its own timestamps, and not all containers are nice enough to use timestamps in their own output.

```
nginx: [emerg] host not found in upstream in /etc/nginx/conf.d/proxy.conf:6
vs
2024-04-09T17:33:12.238986028Z nginx: [emerg] host not found in upstream in /etc/nginx/conf.d/proxy.conf:6
```