### PR TITLE
Includes container log timestamps

### DIFF
--- a/bin/supportconfig
+++ b/bin/supportconfig
@@ -1272,7 +1272,7 @@ docker_info() {
 			CONTAINEROF=docker/"$container".txt
 			log_cmd $CONTAINEROF "docker top $container"
 			log_cmd $CONTAINEROF "docker inspect $container"
-			log_cmd $CONTAINEROF "docker logs $container"
+			log_cmd $CONTAINEROF "docker logs --timestamps $container"
 		done
 		log_cmd $OF 'ls -al --time-style=long-iso /var/lib/docker/containers'
 		log_cmd $OF 'journalctl -u docker'
@@ -1359,7 +1359,7 @@ podman_info() {
 						log_cmd $CONTAINEROF "${PODACC}podman ps --all --pod | egrep \"^CONTAINER|${container}\""
 						log_cmd $CONTAINEROF "${PODACC}podman top $container"
 						log_cmd $CONTAINEROF "${PODACC}podman inspect $container"
-						log_cmd $CONTAINEROF "${PODACC}podman logs $container"
+						log_cmd $CONTAINEROF "${PODACC}podman logs --timestamps $container"
 					done
 					log_cmd $OF "${PODACC}podman network ls"
 					for podnet in $(${PODACC}podman network ls --format "{{.Name}}")


### PR DESCRIPTION
Force add timestamps to container logs. By default, docker and podman logs does not add their own timestamps, and not all containers are nice enough to use timestamps in their own output.
`nginx: [emerg] host not found in upstream in /etc/nginx/conf.d/proxy.conf:6
vs
2024-04-09T17:33:12.238986028Z nginx: [emerg] host not found in upstream in /etc/nginx/conf.d/proxy.conf:6`
