### PR TITLE
hardware_info: remove old alsa ver check

### DIFF
--- a/bin/supportconfig
+++ b/bin/supportconfig
@@ -1526,7 +1526,7 @@ hardware_info() {
 	ALSABIN='/usr/sbin/alsa-info.sh'
 	if [[ -x $ALSABIN ]]; then
 		AVER=$(grep SCRIPT_VERSION= $ALSABIN | cut -d= -f2 | sed -e 's/\.//g')
-		if [[ $((10#$AVER)) -lt $((10#0458)) ]]; then
+		if (( $AVER >= 0458 )); then
 			log_cmd $OF "$ALSABIN --stdout --no-upload --with-configs --with-devices --with-dmesg --with-alsactl"
 		else
 			log_cmd $OF "echo y | $ALSABIN --no-dialog --no-upload --with-configs --with-devices &>/dev/null"

--- a/bin/supportconfig
+++ b/bin/supportconfig
@@ -1525,13 +1525,7 @@ hardware_info() {
 	log_cmd $OF 'ls -al /dev | egrep "fd.*|dvd.*|cdr.*"'
 	ALSABIN='/usr/sbin/alsa-info.sh'
 	if [[ -x $ALSABIN ]]; then
-		AVER=$(grep SCRIPT_VERSION= $ALSABIN | cut -d= -f2 | sed -e 's/\.//g')
-		if (( $AVER >= 0458 )); then
 			log_cmd $OF "$ALSABIN --stdout --no-upload --with-configs --with-devices --with-dmesg --with-alsactl"
-		else
-			log_cmd $OF "echo y | $ALSABIN --no-dialog --no-upload --with-configs --with-devices &>/dev/null"
-			log_files $OF 0 /tmp/alsa-info.txt
-		fi
 	fi
 
 	if [[ "$ARCH" == "s390x" ]]; then


### PR DESCRIPTION
SLE12/15 doesn't have this old Alsa script version, and the way the version check is done is problematic.