### PR TITLE
drbd_info: Fix incorrect escape of quotes

### DIFF
--- a/bin/supportconfig
+++ b/bin/supportconfig
@@ -2906,7 +2906,7 @@ drbd_info() {
 				# We need to add "/etc/" since $DIR will have dir inside /etc/ 
 				# However this find will find all files inside a specific folder It's okay
 				# Will end up with /etc/drbd.conf/nfs.res nfs.RES nfs.stop .... 
-				[[ -d "/etc/$DIR" ]] && FILES="$FILES $(find -L \"/etc/$DIR\" -type f)"
+				[[ -d "/etc/$DIR" ]] && FILES="$FILES $(find -L "/etc/$DIR" -type f)"
 				[[ -d $DIR ]] && FILES="$FILES $(find -L $DIR -type f)"
 			done
 			conf_files $OF "/etc/drbd.conf $FILES"


### PR DESCRIPTION
Fixes `find: '"/etc/drbd.d/"': No such file or directory` errors.