### PR TITLE
net_info_namespace: reliably print second column

### DIFF
--- a/bin/supportconfig
+++ b/bin/supportconfig
@@ -1762,7 +1762,7 @@ net_info_namespace() {
 	ping_addr $OF 'Default Route' $IPADDR "${NS}"
 
 	if [[ -z "${NS}" ]]; then
-		[[ -e /etc/resolv.conf ]] && IPADDRS=$(grep ^nameserver /etc/resolv.conf | cut -d' ' -f2) || IPADDRS=""
+		[[ -e /etc/resolv.conf ]] && IPADDRS=$(grep ^nameserver /etc/resolv.conf | awk '{print $2}') || IPADDRS=""
 		for IPADDR in $IPADDRS
 		do
 			ping_addr $OF 'DNS Server' $IPADDR "${NS}"


### PR DESCRIPTION
Using awk instead of cut to reliably print the second column. Multiple spaces on the line result in incorrect results.