### PR TITLE
Added unknown SLES_VER default for display bsc#1231396

### DIFF
--- a/bin/supportconfig
+++ b/bin/supportconfig
@@ -2229,6 +2229,7 @@ ntp_info() {
 			echolog Skipped
 		fi
 		;;
+		*) echolog Skipped ;;
 	esac
 }
 
@@ -2735,7 +2736,7 @@ ha_info() {
 			echolog Skipped
 		fi
 		;;
-	*) echolog Error ;;
+	*) echolog Skipped ;;
 	esac
 }
 
@@ -3475,6 +3476,7 @@ x_info() {
 			echolog Skipped
 		fi
 	;;
+	*) echolog Skipped ;;
 	esac
 }
 


### PR DESCRIPTION
When no SLES_VER matches, case SLES_VER statements did not have a default action. The default action should be echolog Skipped. This applies to ha_info, ntp_info and x_info.
