### PR TITLE
sanitize_file incorrectly removes text bsc#1232754

### DIFF
--- a/bin/supportconfig.rc
+++ b/bin/supportconfig.rc
@@ -521,21 +521,22 @@ _sanitize_file() {
 	CLEAN_FILE=${LOG}/$1
 	REPLACED='*REMOVED BY SUPPORTCONFIG*'
 	sed -i -e "\
-	s/\(.*[P|p]ass\"\?:\).*/\1 $REPLACED/g;\
-	s/\(.*[P|p]assword\"\?:\).*/\1 $REPLACED/g;\
-	s/\(.*[P|p]ass[[:space:]]*=\).*/\1 $REPLACED/g;\
-	s/\(.*[P|p]assword[[:space:]]*=\).*/\1 $REPLACED/g;\
-	s/\(.*PASS=\).*/\1$REPLACED/g;\
-	s/\(.*_PASSWORD[[:space:]]*=\).*/\1 $REPLACED/g;\
+	s/\([[:space:]][Pp]ass\"\?:\).*/\1 $REPLACED/g;\
+	s/\([Pp]assword\"\?:\).*/\1 $REPLACED/g;\
+	s/\([Pp]ass[[:space:]]*=\).*/\1 $REPLACED/g;\
+	s/\([Pp]assword[[:space:]]*=\).*/\1 $REPLACED/g;\
+	s/\(PASS=\).*/\1$REPLACED/g;\
+	s/\(_PASSWORD[[:space:]]*=\).*/\1 $REPLACED/g;\
 	s!\(<user_password>\).*\(</user_password>\)!\1$REPLACED\2!g;\
 	s/\(^ProxyUser[[:space:]]*=\).*/\1 $REPLACED/g;\
 	s/\(^credentials[[:space:]]*=\).*/\1 $REPLACED/g;\
 	s/\(\"regcode\":\"\)[[:alnum:]_-]*/\1$REPLACED/g;\
 	s/\(secret[[:space:]]*=\).*/\1 $REPLACED/g;\
 	s/\($Param{'[s]*password'}[[:space:]]*=[[:space:]]*'\).*\(';\)/\1$REPLACED\2/g;\
-	s/\(.*password[[:space:]]*=\).*/\1 $REPLACED/g;\
-	s/\(.*password_pbkdf2[[:space:]]\).*/\1 $REPLACED/g;\
-	s/\(.*password_in[[:space:]]*=\).*/\1 $REPLACED/g" \
+	s/\(password[[:space:]]*=\).*/\1 $REPLACED/g;\
+	s/\(password_pbkdf2[[:space:]]\).*/\1 $REPLACED/g;\
+	s/\(password_in[[:space:]]*=\).*/\1 $REPLACED/g; \
+	s/\(^echo -n\).*\(> \/sys\/kernel\/config\/target\/.*auth\/password.*\)/\1 $REPLACED \2/g" \
 	$CLEAN_FILE
 }
 


### PR DESCRIPTION
sanitize_file no longer generates, "kernel: Speculative Store Bypass: *REMOVED BY SUPPORTCONFIG*"