### PR TITLE
Naive d z egrep

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,14 +4,14 @@ SUSE Linux Enterprise support utilities. Gathers system information.
 
 ## Branching Strategy
 
-**master**: Current stable changes for SLE15 and beyond. Protected branch requires pull request from **dev** branch.
-
 **dev**: Unstable branch with current fixes. 
-
-**sle15: DEPRICATED Do not use.** SUSE Linux Enterprise Server 15 branch for all changes to SLE15
 
 **sle12**: SUSE Linux Enterprise Server 12 branch for all changes to SLE12
 
 **sle11**: SUSE Linux Enterprise Server 11 branch for all changes to SLE11
+
+**master**: Current stable changes for SLE15 and beyond. Protected branch requires pull request from **dev** branch.
+
+**sle15: DEPRICATED Do not use.** SUSE Linux Enterprise Server 15 branch for all changes to SLE15
 
 Applicable fixes must be checked into each corresponding branch.

--- a/bin/supportconfig
+++ b/bin/supportconfig
@@ -312,8 +312,8 @@ basic_healthcheck() {
 	log_cmd $PSTMP 'ps axwwo user,pid,ppid,%cpu,%mem,vsz,rss,stat,time,cmd'
 
 	log_write $OF "#==[ Checking Health of Processes ]=================#"
-	log_write $OF "# egrep \" D| Z\" $PSPTMP"
-	log_write $OF "$(grep -v ^# "$PSPTMP" | egrep " D| Z")"
+	log_write $OF "# awk '\$8 ~ /D|Z/' $PSPTMP"
+	log_write $OF "$(awk '!/^#/ && \$8 ~ /D|Z/' "$PSPTMP")"
 
 	TOPTMP=$(mktemp $LOG/top.XXXXXXXX)
 	log_write $OF


### PR DESCRIPTION
solves

``` shell
# egrep " D| Z" /var/log/scc_SR00912028_dest-bmcpkdbl00_231123_1552/psout.5zZ4tQTy
postgres 10631  3780  0.0  0.0 25913948 53064 Ss 00:00:04 postgres: bmcp_readonly ARSystem DESTN45429.itc.global.mahle(49576) idle
```
here it is `DESTN45429.itc.global.mahle(49576)` that matches.
