### PR TITLE
be more explicit when filtering D/Z processes

### DIFF
--- a/bin/supportconfig
+++ b/bin/supportconfig
@@ -312,8 +312,8 @@ basic_healthcheck() {
 	log_cmd $PSTMP 'ps axwwo user,pid,ppid,%cpu,%mem,vsz,rss,stat,time,cmd'
 
 	log_write $OF "#==[ Checking Health of Processes ]=================#"
-	log_write $OF "# egrep \" D| Z\" $PSPTMP"
-	log_write $OF "$(grep -v ^# "$PSPTMP" | egrep " D| Z")"
+        log_write $OF "# awk '\$8 ~ /D|Z/' $PSPTMP"
+        log_write $OF "$(awk '!/^#/ && $8 ~ /D|Z/' "$PSPTMP")"
 
 	TOPTMP=$(mktemp $LOG/top.XXXXXXXX)
 	log_write $OF


### PR DESCRIPTION
solves
``` shell
postgres 10631  3780  0.0  0.0 25913948 53064 Ss 00:00:04 postgres: bmcp_readonly ARSystem DESTN45429.itc.global.mahle(49576) idle
```
here it is `DESTN45429.itc.global.mahle(49576)` that matches.