### PR TITLE
Only run ping when there's default route.

### DIFF
--- a/bin/supportconfig
+++ b/bin/supportconfig
@@ -1827,7 +1827,7 @@ net_info_namespace() {
 	done
 
 	IPADDR=$(${NS}ip route list | awk '$1 == "default" {print $3}')
-	ping_addr $OF 'Default Route' $IPADDR "${NS}"
+	ping_addr $OF 'Default Route' "$IPADDR" "${NS}"
 
 	if [[ -z "${NS}" ]]; then
 		[[ -e /etc/resolv.conf ]] && IPADDRS=$(grep ^nameserver /etc/resolv.conf | awk '{print $2}') || IPADDRS=""


### PR DESCRIPTION
In case we're in a namespace and IPADDR is empty, ping_addr gets it wrong (encountered in bsc#1233749).