### PR TITLE
add nfs.conf.local and show configs in nfs_info as well

### DIFF
--- a/bin/supportconfig
+++ b/bin/supportconfig
@@ -2223,7 +2223,7 @@ nfs_info() {
 		rpm_verify $OF rpcbind
 		log_cmd $OF 'systemctl status nfs.service'
 		log_cmd $OF 'systemctl status rpcbind.service'
-		conf_files $OF /etc/sysconfig/nfs
+		conf_files $OF /etc/nfs.conf /etc/nfs.conf.d/*.conf /etc/nfs.conf.local /etc/sysconfig/nfs
 		log_cmd $OF 'nfsstat'
 		timed_log_cmd $OF 'rpcinfo -p'
 

--- a/bin/supportconfig
+++ b/bin/supportconfig
@@ -3402,7 +3402,7 @@ etc_info() {
 	addHeaderFile $OF
 	# Let us get alternatives output
 	log_cmd $OF "update-alternatives --get-selections"
-	conf_files $OF $(find -L /etc/ -type f | egrep "conf$|cfg$" | egrep -v "rhn/rhn.conf$")
+	conf_files $OF $(find -L /etc/ -type f | egrep "(conf|cfg|nfs.conf.local)$" | egrep -v "rhn/rhn.conf$")
 	[[ -d /etc/logrotate.d ]] && conf_files $OF /etc/logrotate.d/*
 	conf_files $OF /etc/rc.dialout /etc/ppp/options /etc/ppp/ioptions /etc/ppp/peers/pppoe /etc/motd
 	_sanitize_file $OF


### PR DESCRIPTION
SLES/OpenSUSE uses customized nfs.conf which includes nfs.conf.local, plus we document this file on multiple places; but we do not collect it thus it needs another iteraction with customers to get its content; see:

https://build.opensuse.org/projects/Base:System/packages/nfs-utils/files/nfs.conf?expand=1